### PR TITLE
Adds line height to Button

### DIFF
--- a/change/@microsoft-arbutus-button-12bea509-095d-4568-b700-3a878082a26f.json
+++ b/change/@microsoft-arbutus-button-12bea509-095d-4568-b700-3a878082a26f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds line-height to Button",
+  "packageName": "@microsoft/arbutus.button",
+  "email": "akimalunar@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/components/button/src/button/button.styles.ts
+++ b/components/button/src/button/button.styles.ts
@@ -73,25 +73,29 @@ export const sizeMap: SizeMap = {
     x: tokens.spacingHorizontalM,
     y: tokens.spacingVerticalXS,
     fontSize: tokens.fontSizeBase300,
+    lineHeight: tokens.fontSizeBase300,
   },
   medium: {
     x: tokens.spacingHorizontalL,
     y: tokens.spacingVerticalS,
     fontSize: tokens.fontSizeBase300,
+    lineHeight: tokens.fontSizeBase300,
   },
   large: {
     x: tokens.spacingHorizontalXXL,
     y: tokens.spacingVerticalM,
     fontSize: tokens.fontSizeBase400,
+    lineHeight: tokens.fontSizeBase400,
   },
 };
 
-const sizeStyleFunction = ({ y, x, fontSize }: SizeValue) => ({
+const sizeStyleFunction = ({ y, x, fontSize, lineHeight }: SizeValue) => ({
   paddingLeft: x,
   paddingRight: x,
   paddingTop: y,
   paddingBottom: y,
   fontSize,
+  lineHeight,
 });
 
 const sizeClasses = mapToStyles<SizeValue, SizeMap>(sizeMap, sizeStyleFunction);

--- a/components/button/src/button/button.types.ts
+++ b/components/button/src/button/button.types.ts
@@ -14,6 +14,7 @@ export type SizeValue = {
   x: string;
   y: string;
   fontSize: string;
+  lineHeight: string;
 };
 
 export type SizeMap = Record<SizeKey, SizeValue>;

--- a/utilities/docs/src/code-examples/tag-basic.example.tsx
+++ b/utilities/docs/src/code-examples/tag-basic.example.tsx
@@ -1,6 +1,6 @@
 import { Tag } from '@microsoft/arbutus.tag';
 import * as React from 'react';
 
-const ExampleComponent = () => <Tag>Tag</Tag>
+const ExampleComponent = () => <Tag>Tag</Tag>;
 
 export default ExampleComponent;

--- a/utilities/docs/src/code-examples/tag-inline.example.tsx
+++ b/utilities/docs/src/code-examples/tag-inline.example.tsx
@@ -11,4 +11,3 @@ const ExampleComponent = () => (
 );
 
 export default ExampleComponent;
-

--- a/utilities/docs/src/code-examples/text.example.tsx
+++ b/utilities/docs/src/code-examples/text.example.tsx
@@ -45,11 +45,11 @@ const ExampleComponent = () => {
       <Text block as="h3" variant="subtitle" className={space.mb2}>
         Subheading
       </Text>
-      <Text block as="p"  variant="leading">
+      <Text block as="p" variant="leading">
         Leading Lorem ipsum dolor, sit amet consectetur adipisicing elit. Cupiditate modi
-        eveniet dolorum <Text variant='code'>code</Text> assumenda similique a voluptas voluptatum ducimus
-        temporibus. Culpa animi labore molestiae nesciunt suscipit, architecto optio sit
-        iusto.
+        eveniet dolorum <Text variant="code">code</Text> assumenda similique a voluptas
+        voluptatum ducimus temporibus. Culpa animi labore molestiae nesciunt suscipit,
+        architecto optio sit iusto.
       </Text>
 
       <Divider className={space.my8} />
@@ -59,20 +59,30 @@ const ExampleComponent = () => {
       </Text>
       <Text block as="p" variant="paragraph" className={space.mb8}>
         Paragraph Lorem ipsum dolor, sit amet consectetur adipisicing elit. Cupiditate
-        modi eveniet dolorum officiis <Text variant='code'>code</Text> similique a voluptas voluptatum ducimus
-        temporibus. Culpa animi labore molestiae nesciunt suscipit, architecto optio sit
-        iusto.
+        modi eveniet dolorum officiis <Text variant="code">code</Text> similique a
+        voluptas voluptatum ducimus temporibus. Culpa animi labore molestiae nesciunt
+        suscipit, architecto optio sit iusto.
       </Text>
       <div className={classes.grid}>
         <article>
           <div className={classes.image}>&nbsp;</div>
-          <Text block variant='caption' className={space.mb2}>Caption</Text>
-          <Text block variant='description'>Description. Culpa animi labore molestiae nesciunt suscipit. Similique a voluptas voluptatum ducimus temporibus.</Text>
+          <Text block variant="caption" className={space.mb2}>
+            Caption
+          </Text>
+          <Text block variant="description">
+            Description. Culpa animi labore molestiae nesciunt suscipit. Similique a
+            voluptas voluptatum ducimus temporibus.
+          </Text>
         </article>
         <article>
           <div className={classes.image}>&nbsp;</div>
-          <Text block variant='caption' className={space.my2}>Caption</Text>
-          <Text block variant='description'>Description. Culpa animi labore molestiae nesciunt suscipit. Sit amet consectetur adipisicing elit. Cupiditate modi eveniet dolorum.</Text>
+          <Text block variant="caption" className={space.my2}>
+            Caption
+          </Text>
+          <Text block variant="description">
+            Description. Culpa animi labore molestiae nesciunt suscipit. Sit amet
+            consectetur adipisicing elit. Cupiditate modi eveniet dolorum.
+          </Text>
         </article>
       </div>
     </main>

--- a/utilities/docs/src/code-examples/theme-switch.example.tsx
+++ b/utilities/docs/src/code-examples/theme-switch.example.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { useTheme } from '@microsoft/arbutus.theming';
 
 const ExampleComponent = () => {
-  
   // Example of how to implement theme switching.
   const { themeKey, setTheme } = useTheme();
   const isDark = themeKey === 'dark';

--- a/utilities/docs/src/content/pages/components.atoms.theme-switch.json
+++ b/utilities/docs/src/content/pages/components.atoms.theme-switch.json
@@ -116,7 +116,10 @@
         {
           "contentComponentId": "blocks.sandbox",
           "codeFile": "theme-switch.example.tsx",
-          "dependencies": ["@microsoft/arbutus.theme-switch", "@microsoft/arbutus.theming"]
+          "dependencies": [
+            "@microsoft/arbutus.theme-switch",
+            "@microsoft/arbutus.theming"
+          ]
         },
         {
           "contentComponentId": "blocks.heading",


### PR DESCRIPTION
### Changes

- **Button was missing the line-height, which caused the height of the Button to be inconsistent with the vertical rhythm. This PR adds matching line-height tokens to the different Button sizes.**
  - [button.styles](https://github.com/microsoft/blueprints/pull/182/files#diff-2093326e40e03332bff5d8835940c197b6bf6be5d79f3e83975a1b7b3e5dece1)
  - [button.types](https://github.com/microsoft/blueprints/pull/182/files#diff-57d68152863a4b1900ddeb425b6f8fd8d46f300ec1f4e3bbce54cb80917f577c)
- Runs lint.